### PR TITLE
build: changed examples version

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ In this repository you can find some application that can be installed on an Ecl
 Build
 -----
 
+For the complete guide to setup the development environment, please refer to the [Eclipse Kura™ documentation](https://eclipse-kura.github.io/kura/latest/java-application-development/development-environment-setup/).
+
 ### Prerequisites
 
 In order to be able to build the applications for Eclipse Kura™ on your development machine, you need to have the following programs installed in your system:
-    * JDK 17
-    * Maven 3.9.x
+
+* JDK 17
+* Maven 3.9.x
 
 <details>
 <summary>
@@ -91,7 +94,7 @@ You can follow the tutorial from the official [Maven](http://maven.apache.org/in
 Change to the new directory and clone the Applications Eclipse Kura™ repo:
 
 ```bash
-git clone -b develop https://github.com/eclipse-kura/kura-apps.git
+git clone https://github.com/eclipse-kura/kura-apps.git
 ```
 
 Build the entire project:

--- a/README.md
+++ b/README.md
@@ -20,19 +20,16 @@ In this repository you can find some application that can be installed on an Ecl
 
 ### What Applications for Eclipse Kura™ can I build?
 * **Kura™ Examples:** provides examples of component that can be developed for the Eclipse Kura™ framework.
+* **Kura™ Prototypes:** provides prototypes of components that can be developed for the Eclipse Kura™ framework.
 
 Build
 -----
 
 ### Prerequisites
 
-In order to be able to build the applications for Eclipse Kura™ on your development machine, you need to:
-
-1.  Having the following programs installed in your system:
+In order to be able to build the applications for Eclipse Kura™ on your development machine, you need to have the following programs installed in your system:
     * JDK 17
     * Maven 3.9.x
-
-2. Having the Kura Target Definition installed on your m2 local repository.
 
 <details>
 <summary>
@@ -89,30 +86,12 @@ You can follow the tutorial from the official [Maven](http://maven.apache.org/in
 
 </details>
 
-
-#### Installing the Kura Target Definition
-
-To install the Kura Target Definition, you need to clone the Kura repository and build the specific target definition profile.
-
-```bash
-git clone -b develop https://github.com/eclipse-kura/kura
-```
-
-Move inside the newly created directory and build the target definition profile:
-
-```bash
-mvn -f kura/distrib/pom.xml clean install -Ptarget-definition
-```
-
-This process should install the Kura target definition in your local m2 repository.
-
-
 ### Build the Applications for Eclipse Kura™
 
 Change to the new directory and clone the Applications Eclipse Kura™ repo:
 
 ```bash
-git clone -b master https://github.com/eclipse-kura/kura-apps.git
+git clone -b develop https://github.com/eclipse-kura/kura-apps.git
 ```
 
 Build the entire project:
@@ -124,7 +103,13 @@ mvn clean install
 Build the examples only:
 
 ```bash
-mvn -f kura-examples/pom.xml clean install
+mvn clean install -Pkura-examples
+```
+
+Build the prototypes only:
+
+```bash
+mvn clean install -Pkura-addon-prototypes
 ```
 
 > [!TIP]

--- a/kura-apps-bom/README.md
+++ b/kura-apps-bom/README.md
@@ -114,8 +114,7 @@ After importing the BOM, you can use bundles without specifying versions:
 
 The BOM manages the following versions:
 
-- **Example Bundles**: `2.0.0-SNAPSHOT` (except `demo.modbus` which is `3.0.0-SNAPSHOT`)
-- **Raspberry Pi and Wire Development Bundles**: `2.0.0-SNAPSHOT`
+- **Example Bundles**: `3.0.0-SNAPSHOT`
 - **BOM Version**: `6.0.0-SNAPSHOT`
 
 ## Benefits

--- a/kura-apps-bom/pom.xml
+++ b/kura-apps-bom/pom.xml
@@ -38,33 +38,7 @@
     </distributionManagement>
 
     <properties>
-        <!-- Bundle versions (without org.eclipse.kura prefix) -->
-        <demo.heater.version>2.0.0-SNAPSHOT</demo.heater.version>
-        <demo.modbus.version>3.0.0-SNAPSHOT</demo.modbus.version>
-        <example.ble.tisensortag.dbus.version>2.0.0-SNAPSHOT</example.ble.tisensortag.dbus.version>
-        <example.camel.aggregation.version>2.0.0-SNAPSHOT</example.camel.aggregation.version>
-        <example.camel.publisher.version>2.0.0-SNAPSHOT</example.camel.publisher.version>
-        <example.camel.quickstart.version>2.0.0-SNAPSHOT</example.camel.quickstart.version>
-        <example.container.signature.validation.version>2.0.0-SNAPSHOT</example.container.signature.validation.version>
-        <example.driver.sensehat.version>2.0.0-SNAPSHOT</example.driver.sensehat.version>
-        <example.eddystone.advertiser.version>2.0.0-SNAPSHOT</example.eddystone.advertiser.version>
-        <example.eddystone.scanner.version>2.0.0-SNAPSHOT</example.eddystone.scanner.version>
-        <example.gpio.version>2.0.0-SNAPSHOT</example.gpio.version>
-        <example.gpio.led.version>2.0.0-SNAPSHOT</example.gpio.led.version>
-        <example.ibeacon.advertiser.version>2.0.0-SNAPSHOT</example.ibeacon.advertiser.version>
-        <example.ibeacon.scanner.version>2.0.0-SNAPSHOT</example.ibeacon.scanner.version>
-        <example.identity.configuration.extension.version>2.0.0-SNAPSHOT</example.identity.configuration.extension.version>
-        <example.publisher.version>2.0.0-SNAPSHOT</example.publisher.version>
-        <example.rest.authentication.provider.version>2.0.0-SNAPSHOT</example.rest.authentication.provider.version>
-        <example.serial.publisher.version>2.0.0-SNAPSHOT</example.serial.publisher.version>
-        <example.tamper.detection.version>2.0.0-SNAPSHOT</example.tamper.detection.version>
-        <example.wire.logic.multiport.provider.version>2.0.0-SNAPSHOT</example.wire.logic.multiport.provider.version>
-        <example.wire.math.multiport.provider.version>2.0.0-SNAPSHOT</example.wire.math.multiport.provider.version>
-        <example.wire.math.singleport.provider.version>2.0.0-SNAPSHOT</example.wire.math.singleport.provider.version>
-        <example.wire.math.trig.version>2.0.0-SNAPSHOT</example.wire.math.trig.version>
-        <raspberrypi.sensehat.version>2.0.0-SNAPSHOT</raspberrypi.sensehat.version>
-        <raspberrypi.sensehat.example.version>2.0.0-SNAPSHOT</raspberrypi.sensehat.example.version>
-        <wire.devel.component.provider.version>2.0.0-SNAPSHOT</wire.devel.component.provider.version>
+        <kura.examples.version>3.0.0-SNAPSHOT</kura.examples.version>
     </properties>
 
     <dependencyManagement>
@@ -72,136 +46,136 @@
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.demo.heater</artifactId>
-                <version>${demo.heater.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.demo.modbus</artifactId>
-                <version>${demo.modbus.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>        <!-- Example bundles -->
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.ble.tisensortag.dbus</artifactId>
-                <version>${example.ble.tisensortag.dbus.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.camel.aggregation</artifactId>
-                <version>${example.camel.aggregation.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.camel.publisher</artifactId>
-                <version>${example.camel.publisher.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.camel.quickstart</artifactId>
-                <version>${example.camel.quickstart.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.container.signature.validation</artifactId>
-                <version>${example.container.signature.validation.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.driver.sensehat</artifactId>
-                <version>${example.driver.sensehat.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.eddystone.advertiser</artifactId>
-                <version>${example.eddystone.advertiser.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.eddystone.scanner</artifactId>
-                <version>${example.eddystone.scanner.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.gpio</artifactId>
-                <version>${example.gpio.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.gpio.led</artifactId>
-                <version>${example.gpio.led.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.ibeacon.advertiser</artifactId>
-                <version>${example.ibeacon.advertiser.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.ibeacon.scanner</artifactId>
-                <version>${example.ibeacon.scanner.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.identity.configuration.extension</artifactId>
-                <version>${example.identity.configuration.extension.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.publisher</artifactId>
-                <version>${example.publisher.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.rest.authentication.provider</artifactId>
-                <version>${example.rest.authentication.provider.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.serial.publisher</artifactId>
-                <version>${example.serial.publisher.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.tamper.detection</artifactId>
-                <version>${example.tamper.detection.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.wire.logic.multiport.provider</artifactId>
-                <version>${example.wire.logic.multiport.provider.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.wire.math.multiport.provider</artifactId>
-                <version>${example.wire.math.multiport.provider.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.wire.math.singleport.provider</artifactId>
-                <version>${example.wire.math.singleport.provider.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.wire.math.trig</artifactId>
-                <version>${example.wire.math.trig.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
 
             <!-- Raspberry Pi SenseHat bundles -->
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.raspberrypi.sensehat</artifactId>
-                <version>${raspberrypi.sensehat.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.raspberrypi.sensehat.example</artifactId>
-                <version>${raspberrypi.sensehat.example.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
 
             <!-- Wire development component -->
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.wire.devel.component.provider</artifactId>
-                <version>${wire.devel.component.provider.version}</version>
+                <version>${kura.examples.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/kura-examples/bundles/org.eclipse.kura.demo.heater/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.demo.heater/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.demo.heater
 Bundle-SymbolicName: org.eclipse.kura.demo.heater;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Service-Component: OSGI-INF/*.xml

--- a/kura-examples/bundles/org.eclipse.kura.demo.heater/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.demo.heater/pom.xml
@@ -24,7 +24,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.demo.heater</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.ble.tisensortag.dbus/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.ble.tisensortag.dbus/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.example.ble.tisensortag.dbus
 Bundle-SymbolicName: org.eclipse.kura.example.ble.tisensortag.dbus;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Service-Component: OSGI-INF/*.xml
 Import-Package: org.eclipse.kura;version="[1.0,2.0)",

--- a/kura-examples/bundles/org.eclipse.kura.example.ble.tisensortag.dbus/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.ble.tisensortag.dbus/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.example.ble.tisensortag.dbus</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.camel.aggregation/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.camel.aggregation/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.kura.example.camel.aggregation
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Name: Camel Aggregation Example
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Service-Component: OSGI-INF/*.xml

--- a/kura-examples/bundles/org.eclipse.kura.example.camel.aggregation/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.camel.aggregation/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.example.camel.aggregation</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.camel.publisher/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.camel.publisher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Example Camel Publisher
 Bundle-SymbolicName: org.eclipse.kura.example.camel.publisher
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Bundle-ActivationPolicy: lazy

--- a/kura-examples/bundles/org.eclipse.kura.example.camel.publisher/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.camel.publisher/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>org.eclipse.kura.example.camel.publisher</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.camel.quickstart/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.camel.quickstart/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.kura.example.camel.quickstart
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Name: Camel Quickstart
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Service-Component: OSGI-INF/*.xml

--- a/kura-examples/bundles/org.eclipse.kura.example.camel.quickstart/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.camel.quickstart/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 	
 	<artifactId>org.eclipse.kura.example.camel.quickstart</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
     
     <properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.can/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.can/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.example.can
 Bundle-SymbolicName: org.eclipse.kura.example.can;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse Kura
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"

--- a/kura-examples/bundles/org.eclipse.kura.example.can/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.can/pom.xml
@@ -25,7 +25,7 @@
 
 	<artifactId>org.eclipse.kura.example.can</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 
 	<properties>
 		<kura.basedir>${project.basedir}/../..</kura.basedir>

--- a/kura-examples/bundles/org.eclipse.kura.example.container.signature.validation/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.container.signature.validation/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.example.container.signature.validation
 Bundle-SymbolicName: org.eclipse.kura.example.container.signature.validation;singletone:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Service-Component: OSGI-INF/*.xml

--- a/kura-examples/bundles/org.eclipse.kura.example.container.signature.validation/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.container.signature.validation/pom.xml
@@ -25,7 +25,7 @@
 
 	<artifactId>org.eclipse.kura.example.container.signature.validation</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 
 	<properties>
 		<kura.basedir>${project.basedir}/../..</kura.basedir>

--- a/kura-examples/bundles/org.eclipse.kura.example.driver.sensehat/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.driver.sensehat/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SenseHat Driver
 Bundle-SymbolicName: org.eclipse.kura.example.driver.sensehat;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Bundle-License: Eclipse Public License v2.0
 Bundle-Category: Asset-Driver Management

--- a/kura-examples/bundles/org.eclipse.kura.example.driver.sensehat/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.driver.sensehat/pom.xml
@@ -24,7 +24,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.example.driver.sensehat</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.eddystone.advertiser/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.eddystone.advertiser/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.example.eddystone.advertiser
 Bundle-SymbolicName: org.eclipse.kura.example.eddystone.advertiser;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Service-Component: OSGI-INF/*.xml
 Import-Package: org.eclipse.kura;version="[1.4,2.0)",

--- a/kura-examples/bundles/org.eclipse.kura.example.eddystone.advertiser/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.eddystone.advertiser/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.example.eddystone.advertiser</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.eddystone.scanner/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.eddystone.scanner/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.example.eddystone.scanner
 Bundle-SymbolicName: org.eclipse.kura.example.eddystone.scanner;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy

--- a/kura-examples/bundles/org.eclipse.kura.example.eddystone.scanner/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.eddystone.scanner/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.example.eddystone.scanner</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.gpio.led/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.gpio.led/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Configurable Led Example
 Bundle-SymbolicName: org.eclipse.kura.example.gpio.led
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Automatic-Module-Name: org.eclipse.kura.example.gpio.led
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Import-Package: org.eclipse.kura.configuration;version="[1.2,1.3)",

--- a/kura-examples/bundles/org.eclipse.kura.example.gpio.led/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.gpio.led/pom.xml
@@ -24,7 +24,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.example.gpio.led</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.gpio/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.gpio/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.example.gpio
 Bundle-SymbolicName: org.eclipse.kura.example.gpio;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Service-Component: OSGI-INF/*.xml

--- a/kura-examples/bundles/org.eclipse.kura.example.gpio/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.gpio/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.example.gpio</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.ibeacon.advertiser/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.ibeacon.advertiser/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.example.ibeacon.advertiser
 Bundle-SymbolicName: org.eclipse.kura.example.ibeacon.advertiser;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Service-Component: OSGI-INF/*.xml
 Import-Package: org.eclipse.kura;version="1.4.0",

--- a/kura-examples/bundles/org.eclipse.kura.example.ibeacon.advertiser/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.ibeacon.advertiser/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.example.ibeacon.advertiser</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.ibeacon.scanner/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.ibeacon.scanner/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.example.ibeacon.scanner
 Bundle-SymbolicName: org.eclipse.kura.example.ibeacon.scanner;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy

--- a/kura-examples/bundles/org.eclipse.kura.example.ibeacon.scanner/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.ibeacon.scanner/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.example.ibeacon.scanner</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.identity.configuration.extension/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.identity.configuration.extension/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.example.identity.configuration.extension
 Bundle-SymbolicName: org.eclipse.kura.example.identity.configuration.extension;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy

--- a/kura-examples/bundles/org.eclipse.kura.example.identity.configuration.extension/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.identity.configuration.extension/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.example.identity.configuration.extension</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.publisher/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.publisher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.example.publisher
 Bundle-SymbolicName: org.eclipse.kura.example.publisher;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Service-Component: OSGI-INF/*.xml

--- a/kura-examples/bundles/org.eclipse.kura.example.publisher/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.publisher/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.example.publisher</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.rest.authentication.provider/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.rest.authentication.provider/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.example.rest.authentication.provider
 Bundle-SymbolicName: org.eclipse.kura.example.rest.authentication.provider;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Service-Component: OSGI-INF/*.xml

--- a/kura-examples/bundles/org.eclipse.kura.example.rest.authentication.provider/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.rest.authentication.provider/pom.xml
@@ -24,7 +24,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.example.rest.authentication.provider</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.serial.publisher/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.serial.publisher/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.example.serial.publisher
 Bundle-SymbolicName: org.eclipse.kura.example.serial.publisher;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Service-Component: OSGI-INF/*.xml

--- a/kura-examples/bundles/org.eclipse.kura.example.serial.publisher/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.serial.publisher/pom.xml
@@ -24,7 +24,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.example.serial.publisher</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.tamper.detection/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.tamper.detection/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.example.tamper.detection
 Bundle-SymbolicName: org.eclipse.kura.example.tamper.detection;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Service-Component: OSGI-INF/*.xml

--- a/kura-examples/bundles/org.eclipse.kura.example.tamper.detection/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.tamper.detection/pom.xml
@@ -24,7 +24,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.example.tamper.detection</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.wire.logic.multiport.provider/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.wire.logic.multiport.provider/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.kura.example.wire.logic.multiport.provider;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Name: Logical Operators for Wires
 Bundle-Category: Kura Wires
 Bundle-Vendor: Eclipse Kura

--- a/kura-examples/bundles/org.eclipse.kura.example.wire.logic.multiport.provider/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.wire.logic.multiport.provider/pom.xml
@@ -24,7 +24,7 @@
     </parent>
 
     <artifactId>org.eclipse.kura.example.wire.logic.multiport.provider</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.wire.math.multiport.provider/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.wire.math.multiport.provider/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Multiport Math Wire Component Provider
 Bundle-SymbolicName: org.eclipse.kura.example.wire.math.multiport.provider;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Bundle-License: Eclipse Public License v2.0
 Bundle-Category: Kura Wires

--- a/kura-examples/bundles/org.eclipse.kura.example.wire.math.multiport.provider/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.wire.math.multiport.provider/pom.xml
@@ -24,7 +24,7 @@
     </parent>
 
     <artifactId>org.eclipse.kura.example.wire.math.multiport.provider</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.wire.math.singleport.provider/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.wire.math.singleport.provider/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Singleport Math Wire Component Provider
 Bundle-SymbolicName: org.eclipse.kura.example.wire.math.singleport.provider;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Bundle-License: Eclipse Public License v2.0
 Bundle-Category: Kura Wires

--- a/kura-examples/bundles/org.eclipse.kura.example.wire.math.singleport.provider/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.wire.math.singleport.provider/pom.xml
@@ -24,7 +24,7 @@
     </parent>
 
     <artifactId>org.eclipse.kura.example.wire.math.singleport.provider</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>eclipse-plugin</packaging>
 
     <properties>

--- a/kura-examples/bundles/org.eclipse.kura.example.wire.math.trig/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.example.wire.math.trig/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Trigonometric Functions for Wires
 Bundle-SymbolicName: org.eclipse.kura.example.wire.math.trig;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Bundle-License: Eclipse Public License v2.0
 Bundle-Category: Kura Wires

--- a/kura-examples/bundles/org.eclipse.kura.example.wire.math.trig/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.example.wire.math.trig/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.example.wire.math.trig</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/bundles/org.eclipse.kura.raspberrypi.sensehat.example/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.raspberrypi.sensehat.example/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.raspberrypi.sensehat.example
 Bundle-SymbolicName: org.eclipse.kura.raspberrypi.sensehat.example;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Service-Component: OSGI-INF/*.xml
 Bundle-ClassPath: .

--- a/kura-examples/bundles/org.eclipse.kura.raspberrypi.sensehat.example/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.raspberrypi.sensehat.example/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.raspberrypi.sensehat.example</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/bundles/org.eclipse.kura.raspberrypi.sensehat/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.raspberrypi.sensehat/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.raspberrypi.sensehat
 Bundle-SymbolicName: org.eclipse.kura.raspberrypi.sensehat;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Service-Component: OSGI-INF/*.xml
 Import-Package: jdk.dio;version="[1.0.2,2.0.0)",

--- a/kura-examples/bundles/org.eclipse.kura.raspberrypi.sensehat/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.raspberrypi.sensehat/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.raspberrypi.sensehat</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/bundles/org.eclipse.kura.wire.devel.component.provider/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/org.eclipse.kura.wire.devel.component.provider/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.wire.devel.component.provider
 Bundle-SymbolicName: org.eclipse.kura.wire.devel.component.provider
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.kura;version="[1.0,2.0)",
  org.eclipse.kura.channel;version="[1.0,2.0)",

--- a/kura-examples/bundles/org.eclipse.kura.wire.devel.component.provider/pom.xml
+++ b/kura-examples/bundles/org.eclipse.kura.wire.devel.component.provider/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.wire.devel.component.provider</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>

--- a/kura-examples/distrib/pom.xml
+++ b/kura-examples/distrib/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.demo.heater</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
@@ -52,126 +52,126 @@
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.ble.tisensortag.dbus</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.camel.aggregation</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.camel.publisher</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.camel.quickstart</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.container.signature.validation</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.driver.sensehat</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.eddystone.advertiser</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.eddystone.scanner</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.gpio</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.gpio.led</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.ibeacon.advertiser</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.ibeacon.scanner</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.identity.configuration.extension</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.publisher</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.rest.authentication.provider</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.serial.publisher</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.tamper.detection</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.wire.logic.multiport.provider</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.wire.math.multiport.provider</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.wire.math.singleport.provider</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.wire.math.trig</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
 
         <!-- Raspberry Pi SenseHat bundles -->
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.raspberrypi.sensehat</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.raspberrypi.sensehat.example</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
 
         <!-- Wire development component -->
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.wire.devel.component.provider</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/kura-examples/tests/org.eclipse.kura.example.identity.configuration.extension.test/META-INF/MANIFEST.MF
+++ b/kura-examples/tests/org.eclipse.kura.example.identity.configuration.extension.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.example.identity.configuration.extension.test
 Bundle-SymbolicName: org.eclipse.kura.example.identity.configuration.extension.test;singleton:=true
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 3.0.0.qualifier
 Import-Package: org.eclipse.kura.configuration;version="[1.2,2.0)",
  org.eclipse.kura.configuration.metatype;version="1.1.0",
  org.eclipse.kura.identity.configuration.extension;version="[1.0,2.0)",

--- a/kura-examples/tests/org.eclipse.kura.example.identity.configuration.extension.test/pom.xml
+++ b/kura-examples/tests/org.eclipse.kura.example.identity.configuration.extension.test/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>org.eclipse.kura.example.identity.configuration.extension.test</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>eclipse-test-plugin</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -43,15 +43,6 @@
 
     <profiles>
         <profile>
-            <id>kura-apps-target-definition</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <modules>
-                <module>kura-apps-target-definition</module>
-            </modules>
-        </profile>
-        <profile>
             <id>kura-examples</id>
             <activation>
                 <activeByDefault>true</activeByDefault>


### PR DESCRIPTION
This PR aligns all the examples to the higher version available (namely 3.0.0 of `demo.modbus`) in order to have a simple build and pom.xml references