### PR TITLE
build: adding deploy stage in jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,10 +29,16 @@ spec:
         }
 
         stage('Build Kura-apps') {
+            def mavenBuildType = 'deploy'
+            if (!env.BRANCH_IS_PRIMARY) {
+                echo 'Skipping deploy for non-main branch'
+                mavenBuildType = 'install'
+            }
+
             timeout(time: 2, unit: 'HOURS') {
                 dir('kura-apps') {
                     withMaven(jdk: 'temurin-jdk17-latest', maven: 'apache-maven-3.9.6') {
-                        sh 'mvn clean install'
+                        sh "mvn clean ${mavenBuildType}"
                     }
                 }
             }


### PR DESCRIPTION
This PR adds the deploy staging in the Jenkinsfile with the aim of deployng the following artifacts:

- `kura-apps-bom`
- `kura-examples`
- `kura-addon-prototypes`

The deploy stage is done only when the main branch is built (currently `master` but it's migrating to `develop`)