### PR TITLE
chore: Removed parent pom reference from kura-examples-bom

### DIFF
--- a/kura-examples/kura-examples-bom/pom.xml
+++ b/kura-examples/kura-examples-bom/pom.xml
@@ -18,13 +18,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.eclipse.kura</groupId>
-        <artifactId>kura-examples</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
-    </parent>
-
+    <groupId>org.eclipse.kura</groupId>
     <artifactId>kura-examples-bom</artifactId>
+    <version>6.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Eclipse Kura Examples BOM</name>
 


### PR DESCRIPTION
This pull request makes a minor update to the `kura-examples-bom/pom.xml` file by removing the parent POM declaration and inlining the version directly in this BOM module.

- Removed the `<parent>` section and added the `<version>` tag directly to the `pom.xml` for `kura-examples-bom`, making the BOM module standalone.