### PR TITLE
fix(example.gpio): Updated to new apis

### DIFF
--- a/kura-apps-distrib/kura-examples/pom.xml
+++ b/kura-apps-distrib/kura-examples/pom.xml
@@ -42,7 +42,7 @@
         <module>modbus</module>
         <module>publishers</module>
         <module>security</module>
-        <module>sensehat</module>
+        <!--<module>sensehat</module>-->
         <module>wire-components</module>
     </modules>
 

--- a/kura-apps-target-definition/kura-apps.target
+++ b/kura-apps-target-definition/kura-apps.target
@@ -13,7 +13,8 @@
     Contributors:
      Eurotech
 
---><target name="kura-apps Target Definition" sequenceNumber="75">
+-->
+<target name="kura-apps Target Definition" sequenceNumber="75">
     <locations>
         <location includeDependencyDepth="direct" includeDependencyScopes="compile,test"
             missingManifest="ignore" type="Maven">

--- a/kura-examples/bundles/gpio/org.eclipse.kura.example.gpio/META-INF/MANIFEST.MF
+++ b/kura-examples/bundles/gpio/org.eclipse.kura.example.gpio/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=17))"
 Service-Component: OSGI-INF/*.xml
 Import-Package: org.eclipse.kura;version="[1.0,2.0)",
  org.eclipse.kura.configuration;version="[1.0,2.0)",
- org.eclipse.kura.gpio;version="1.0.0",
+ org.eclipse.kura.gpio;version="[1.2,2.0)",
  org.osgi.framework;version="1.8.0",
  org.osgi.service.component;version="1.2.0",
  org.osgi.util.tracker;version="1.5.1",

--- a/kura-examples/bundles/gpio/org.eclipse.kura.example.gpio/src/main/java/org/eclipse/kura/example/gpio/GpioComponent.java
+++ b/kura-examples/bundles/gpio/org.eclipse.kura.example.gpio/src/main/java/org/eclipse/kura/example/gpio/GpioComponent.java
@@ -239,7 +239,7 @@ public class GpioComponent implements ConfigurableComponent {
         KuraGPIOPin pin = null;
         try {
             int terminal = Integer.parseInt(resource);
-            if (terminal > 0 && terminal < 1255) {
+            if (terminal > 0 && terminal < 100000) {
                 pin = this.gpioService.getPinByTerminal(Integer.parseInt(resource), pinDirection, pinMode, pinTrigger);
             }
         } catch (NumberFormatException e) {

--- a/kura-examples/bundles/gpio/org.eclipse.kura.example.gpio/src/main/java/org/eclipse/kura/example/gpio/GpioComponent.java
+++ b/kura-examples/bundles/gpio/org.eclipse.kura.example.gpio/src/main/java/org/eclipse/kura/example/gpio/GpioComponent.java
@@ -18,8 +18,7 @@ import static java.util.Objects.nonNull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -29,6 +28,7 @@ import java.util.stream.Stream;
 import org.eclipse.kura.configuration.ConfigurableComponent;
 import org.eclipse.kura.gpio.GPIOService;
 import org.eclipse.kura.gpio.KuraClosedDeviceException;
+import org.eclipse.kura.gpio.KuraGPIODescription;
 import org.eclipse.kura.gpio.KuraGPIODirection;
 import org.eclipse.kura.gpio.KuraGPIOMode;
 import org.eclipse.kura.gpio.KuraGPIOPin;
@@ -62,8 +62,10 @@ import org.slf4j.LoggerFactory;
 public class GpioComponent implements ConfigurableComponent {
 
     /**
-     * Inner class defined to track the CloudServices as they get added, modified or removed.
-     * Specific methods can refresh the cloudService definition and setup again the Cloud Client.
+     * Inner class defined to track the CloudServices as they get added, modified or
+     * removed.
+     * Specific methods can refresh the cloudService definition and setup again the
+     * Cloud Client.
      *
      */
     private final class GPIOServiceTrackerCustomizer implements ServiceTrackerCustomizer<GPIOService, GPIOService> {
@@ -193,9 +195,14 @@ public class GpioComponent implements ConfigurableComponent {
         if (this.gpioService != null) {
             logger.info("______________________________");
             logger.info("Available GPIOs on the system:");
-            Map<Integer, String> gpios = this.gpioService.getAvailablePins();
-            for (Entry<Integer, String> e : gpios.entrySet()) {
-                logger.info("#{} - [{}]", e.getKey(), e.getValue());
+            List<KuraGPIODescription> gpioDescriptions = this.gpioService.getAvailablePinDescriptions();
+            for (KuraGPIODescription desc : gpioDescriptions) {
+                Optional<String> name = desc.getName();
+                if (name.isPresent()) {
+                    logger.info("#{}:{} - [{}]", desc.getController(), desc.getLine(), name.get());
+                } else {
+                    logger.info("#{}:{} - [UNKNOWN]", desc.getController(), desc.getLine());
+                }
             }
             logger.info("______________________________");
             getPins();
@@ -237,22 +244,27 @@ public class GpioComponent implements ConfigurableComponent {
     private KuraGPIOPin getPin(String resource, KuraGPIODirection pinDirection, KuraGPIOMode pinMode,
             KuraGPIOTrigger pinTrigger) {
         KuraGPIOPin pin = null;
-        // Resource can be terminal number, pin name or in the format gpiochip,line.
-        // i.e.  "1024" or "GPIO1_24" or "1,24"
-        String[] parts = resource.split(",");
+        // Resource can be terminal number, pin name or in the format controller:line.
+        // i.e. "1024" or "GPIO1_24" or "1:24"
+        String[] parts = resource.split(":");
         try {
             if (parts.length == 2) {
-                int gpiochip = Integer.parseInt(parts[0].trim());
+                int controller = Integer.parseInt(parts[0].trim());
                 int line = Integer.parseInt(parts[1].trim());
-                pin = this.gpioService.getPinByGpiochipAndLine(gpiochip, line, pinDirection, pinMode, pinTrigger);
+                pin = this.gpioService.getPin(controller, line, pinDirection, pinMode, pinTrigger);
             } else {
                 int terminal = Integer.parseInt(resource);
                 if (terminal > 0 && terminal < 100000) {
-                    pin = this.gpioService.getPinByTerminal(Integer.parseInt(resource), pinDirection, pinMode, pinTrigger);
+                    pin = this.gpioService.getPinByTerminal(Integer.parseInt(resource), pinDirection, pinMode,
+                            pinTrigger);
                 }
             }
         } catch (NumberFormatException e) {
-            pin = this.gpioService.getPinByName(resource, pinDirection, pinMode, pinTrigger);
+            List<KuraGPIOPin> pinsByName = this.gpioService.getPins(resource, pinDirection, pinMode,
+                    pinTrigger);
+            if (!pinsByName.isEmpty()) {
+                pin = pinsByName.get(0);
+            }
         } catch (IllegalArgumentException e1) {
             logger.error("Invalid GPIO pin parameters!", e1);
         }
@@ -331,42 +343,42 @@ public class GpioComponent implements ConfigurableComponent {
 
     private KuraGPIODirection getPinDirection(int direction) {
         switch (direction) {
-        case 0, 2:
-            return KuraGPIODirection.INPUT;
-        case 1, 3:
-            return KuraGPIODirection.OUTPUT;
-        default:
-            return KuraGPIODirection.OUTPUT;
+            case 0, 2:
+                return KuraGPIODirection.INPUT;
+            case 1, 3:
+                return KuraGPIODirection.OUTPUT;
+            default:
+                return KuraGPIODirection.OUTPUT;
         }
     }
 
     private KuraGPIOMode getPinMode(int mode) {
         switch (mode) {
-        case 2:
-            return KuraGPIOMode.INPUT_PULL_DOWN;
-        case 1:
-            return KuraGPIOMode.INPUT_PULL_UP;
-        case 8:
-            return KuraGPIOMode.OUTPUT_OPEN_DRAIN;
-        case 4:
-            return KuraGPIOMode.OUTPUT_PUSH_PULL;
-        default:
-            return KuraGPIOMode.OUTPUT_OPEN_DRAIN;
+            case 2:
+                return KuraGPIOMode.INPUT_PULL_DOWN;
+            case 1:
+                return KuraGPIOMode.INPUT_PULL_UP;
+            case 8:
+                return KuraGPIOMode.OUTPUT_OPEN_DRAIN;
+            case 4:
+                return KuraGPIOMode.OUTPUT_PUSH_PULL;
+            default:
+                return KuraGPIOMode.OUTPUT_OPEN_DRAIN;
         }
     }
 
     private KuraGPIOTrigger getPinTrigger(int trigger) {
         switch (trigger) {
-        case 0:
-            return KuraGPIOTrigger.NONE;
-        case 2:
-            return KuraGPIOTrigger.RAISING_EDGE;
-        case 3:
-            return KuraGPIOTrigger.BOTH_EDGES;
-        case 1:
-            return KuraGPIOTrigger.FALLING_EDGE;
-        default:
-            return KuraGPIOTrigger.NONE;
+            case 0:
+                return KuraGPIOTrigger.NONE;
+            case 2:
+                return KuraGPIOTrigger.RAISING_EDGE;
+            case 3:
+                return KuraGPIOTrigger.BOTH_EDGES;
+            case 1:
+                return KuraGPIOTrigger.FALLING_EDGE;
+            default:
+                return KuraGPIOTrigger.NONE;
         }
     }
 

--- a/kura-examples/bundles/gpio/org.eclipse.kura.example.gpio/src/main/java/org/eclipse/kura/example/gpio/GpioComponent.java
+++ b/kura-examples/bundles/gpio/org.eclipse.kura.example.gpio/src/main/java/org/eclipse/kura/example/gpio/GpioComponent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2026 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -229,7 +229,7 @@ public class GpioComponent implements ConfigurableComponent {
             } catch (IOException e) {
                 logger.error("I/O Error occurred!", e);
             } catch (Exception e) {
-                logger.error("got errror", e);
+                logger.error("got error", e);
             }
         }
     }
@@ -237,13 +237,24 @@ public class GpioComponent implements ConfigurableComponent {
     private KuraGPIOPin getPin(String resource, KuraGPIODirection pinDirection, KuraGPIOMode pinMode,
             KuraGPIOTrigger pinTrigger) {
         KuraGPIOPin pin = null;
+        // Resource can be terminal number, pin name or in the format gpiochip,line.
+        // i.e.  "1024" or "GPIO1_24" or "1,24"
+        String[] parts = resource.split(",");
         try {
-            int terminal = Integer.parseInt(resource);
-            if (terminal > 0 && terminal < 100000) {
-                pin = this.gpioService.getPinByTerminal(Integer.parseInt(resource), pinDirection, pinMode, pinTrigger);
+            if (parts.length == 2) {
+                int gpiochip = Integer.parseInt(parts[0].trim());
+                int line = Integer.parseInt(parts[1].trim());
+                pin = this.gpioService.getPinByGpiochipAndLine(gpiochip, line, pinDirection, pinMode, pinTrigger);
+            } else {
+                int terminal = Integer.parseInt(resource);
+                if (terminal > 0 && terminal < 100000) {
+                    pin = this.gpioService.getPinByTerminal(Integer.parseInt(resource), pinDirection, pinMode, pinTrigger);
+                }
             }
         } catch (NumberFormatException e) {
             pin = this.gpioService.getPinByName(resource, pinDirection, pinMode, pinTrigger);
+        } catch (IllegalArgumentException e1) {
+            logger.error("Invalid GPIO pin parameters!", e1);
         }
         return pin;
     }

--- a/kura-examples/bundles/gpio/org.eclipse.kura.example.gpio/src/main/java/org/eclipse/kura/example/gpio/GpioComponent.java
+++ b/kura-examples/bundles/gpio/org.eclipse.kura.example.gpio/src/main/java/org/eclipse/kura/example/gpio/GpioComponent.java
@@ -17,8 +17,9 @@ import static java.util.Objects.nonNull;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -29,6 +30,7 @@ import org.eclipse.kura.configuration.ConfigurableComponent;
 import org.eclipse.kura.gpio.GPIOService;
 import org.eclipse.kura.gpio.KuraClosedDeviceException;
 import org.eclipse.kura.gpio.KuraGPIODescription;
+import org.eclipse.kura.gpio.KuraGPIODeviceException;
 import org.eclipse.kura.gpio.KuraGPIODirection;
 import org.eclipse.kura.gpio.KuraGPIOMode;
 import org.eclipse.kura.gpio.KuraGPIOPin;
@@ -197,12 +199,8 @@ public class GpioComponent implements ConfigurableComponent {
             logger.info("Available GPIOs on the system:");
             List<KuraGPIODescription> gpioDescriptions = this.gpioService.getAvailablePinDescriptions();
             for (KuraGPIODescription desc : gpioDescriptions) {
-                Optional<String> name = desc.getName();
-                if (name.isPresent()) {
-                    logger.info("#{}:{} - [{}]", desc.getController(), desc.getLine(), name.get());
-                } else {
-                    logger.info("#{}:{} - [UNKNOWN]", desc.getController(), desc.getLine());
-                }
+                logger.info("GPIO Pin Description: {}", desc.getDisplayName());
+                logger.debug("GPIO Extended Pin Description: {}", desc.getProperties());
             }
             logger.info("______________________________");
             getPins();
@@ -216,57 +214,81 @@ public class GpioComponent implements ConfigurableComponent {
         int[] triggers = this.gpioComponentOptions.getTriggers();
         for (int i = 0; i < pins.length; i++) {
             try {
-                logger.info("Acquiring GPIO pin {} with params:", pins[i]);
+                String pin = pins[i];
+                logger.info("Acquiring GPIO pin {} with params:", pin);
                 logger.info("   Direction....: {}", directions[i]);
                 logger.info("   Mode.........: {}", modes[i]);
                 logger.info("   Trigger......: {}", triggers[i]);
-                KuraGPIOPin p = getPin(pins[i], getPinDirection(directions[i]), getPinMode(modes[i]),
+                List<KuraGPIOPin> acquiredPins = getPins(pin, getPinDirection(directions[i]), getPinMode(modes[i]),
                         getPinTrigger(triggers[i]));
-                if (p != null) {
-                    p.open();
-                    logger.info("GPIO pin {} acquired", pins[i]);
-                    if (p.getDirection() == KuraGPIODirection.OUTPUT) {
-                        acquiredOutputPins.add(p);
-                    } else {
-                        acquiredInputPins.add(p);
+                acquiredPins.forEach(p -> {
+                    try {
+                        p.open();
+                        logger.info("GPIO pin {} acquired", pin);
+                        if (p.getDirection() == KuraGPIODirection.OUTPUT) {
+                            acquiredOutputPins.add(p);
+                        } else {
+                            acquiredInputPins.add(p);
+                        }
+                    } catch (IOException | KuraGPIODeviceException | KuraUnavailableDeviceException e) {
+                        logger.error("I/O Error occurred!", e);
                     }
-                } else {
-                    logger.info("GPIO pin {} not found", pins[i]);
-                }
-            } catch (IOException e) {
-                logger.error("I/O Error occurred!", e);
+                });
             } catch (Exception e) {
                 logger.error("got error", e);
             }
         }
     }
 
-    private KuraGPIOPin getPin(String resource, KuraGPIODirection pinDirection, KuraGPIOMode pinMode,
+    private List<KuraGPIOPin> getPins(String resource, KuraGPIODirection pinDirection, KuraGPIOMode pinMode,
             KuraGPIOTrigger pinTrigger) {
-        KuraGPIOPin pin = null;
-        // Resource can be terminal number, pin name or in the format controller:line.
-        // i.e. "1024" or "GPIO1_24" or "1:24"
+        List<KuraGPIOPin> pins = new ArrayList<>();
+        // Resource can be terminal number, pin name or in the format
+        // pinName:controller:line.
+        // i.e. "1024" or "GPIO1_24" or "PIN:1:24"
+        // In the latter case, omitting a field or setting to * means all, i.e. ":1:24"
+        // or "PIN:*:24" or "PIN:1:"
         String[] parts = resource.split(":");
         try {
-            if (parts.length == 2) {
-                int controller = Integer.parseInt(parts[0].trim());
-                int line = Integer.parseInt(parts[1].trim());
-                pin = this.gpioService.getPin(controller, line, pinDirection, pinMode, pinTrigger);
-            } else {
-                int terminal = Integer.parseInt(resource);
-                if (terminal > 0 && terminal < 100000) {
-                    pin = this.gpioService.getPinByTerminal(Integer.parseInt(resource), pinDirection, pinMode,
+            switch (parts.length) {
+                case 1:
+                    KuraGPIOPin pin = getPinByNameOrTerminal(parts, pinDirection, pinMode, pinTrigger);
+                    if (pin != null) {
+                        pins.add(pin);
+                    }
+                    break;
+                case 3:
+                    Map<String, String> pinDescription = new HashMap<>();
+                    if (!parts[0].trim().isEmpty() && !parts[0].trim().equals("*")) {
+                        pinDescription.put("name", parts[0].trim());
+                    }
+                    if (!parts[1].trim().isEmpty() && !parts[1].trim().equals("*")) {
+                        pinDescription.put("controller", parts[1].trim());
+                    }
+                    if (!parts[2].trim().isEmpty() && !parts[2].trim().equals("*")) {
+                        pinDescription.put("line", parts[2].trim());
+                    }
+                    pins = this.gpioService.getPins(pinDescription, pinDirection, pinMode,
                             pinTrigger);
-                }
+                    break;
+                default:
+                    logger.error("Invalid GPIO pin resource format: {}", resource);
+                    break;
             }
+        } catch (IllegalArgumentException e) {
+            logger.error("Invalid GPIO pin parameters!", e);
+        }
+        return pins;
+    }
+
+    private KuraGPIOPin getPinByNameOrTerminal(String[] parts, KuraGPIODirection pinDirection, KuraGPIOMode pinMode,
+            KuraGPIOTrigger pinTrigger) {
+        KuraGPIOPin pin = null;
+        try {
+            int terminal = Integer.parseInt(parts[0].trim());
+            pin = this.gpioService.getPinByTerminal(terminal, pinDirection, pinMode, pinTrigger);
         } catch (NumberFormatException e) {
-            List<KuraGPIOPin> pinsByName = this.gpioService.getPins(resource, pinDirection, pinMode,
-                    pinTrigger);
-            if (!pinsByName.isEmpty()) {
-                pin = pinsByName.get(0);
-            }
-        } catch (IllegalArgumentException e1) {
-            logger.error("Invalid GPIO pin parameters!", e1);
+            pin = this.gpioService.getPinByName(parts[0].trim(), pinDirection, pinMode, pinTrigger);
         }
         return pin;
     }

--- a/kura-examples/bundles/gpio/org.eclipse.kura.example.gpio/src/main/java/org/eclipse/kura/example/gpio/GpioComponentOCD.java
+++ b/kura-examples/bundles/gpio/org.eclipse.kura.example.gpio/src/main/java/org/eclipse/kura/example/gpio/GpioComponentOCD.java
@@ -45,7 +45,7 @@ public @interface GpioComponentOCD {
     String gpio_input_read_mode() default "PIN_STATUS_LISTENER";
 
     @AttributeDefinition(name = "Gpio Pins", //
-            description = "List of GPIO pins expressed as pin number or pin name (i.e. DOUT1, DIN1, ...).", //
+            description = "List of GPIO pins expressed as pin number (i.e. 1022), pin name (i.e. DOUT1, DIN1, ...) or gpiochip, line (i.e. 0,24).", //
             required = false, //
             cardinality = 5 //
     )

--- a/kura-examples/bundles/gpio/org.eclipse.kura.example.gpio/src/main/java/org/eclipse/kura/example/gpio/GpioComponentOCD.java
+++ b/kura-examples/bundles/gpio/org.eclipse.kura.example.gpio/src/main/java/org/eclipse/kura/example/gpio/GpioComponentOCD.java
@@ -44,7 +44,8 @@ public @interface GpioComponentOCD {
         String gpio_input_read_mode() default "PIN_STATUS_LISTENER";
 
         @AttributeDefinition(name = "Gpio Pins", //
-                        description = "List of GPIO pins expressed as pin number (i.e. 1022), pin name (i.e. DOUT1, DIN1, ...) or controller:line (i.e. 0:24).", //
+                        description = "List of GPIO pins expressed as pin number (i.e. 1022), pin name (i.e. DOUT1, DIN1, ...) or name:controller:line (i.e. GPIO1:0:24). " //
+                                        + "In the latter case, omitting a field or setting to * means all, i.e. \":1:24\" or \"PIN:*:24\" or \"PIN:1:\"", //
                         required = false, //
                         cardinality = 5 //
         )

--- a/kura-examples/bundles/gpio/org.eclipse.kura.example.gpio/src/main/java/org/eclipse/kura/example/gpio/GpioComponentOCD.java
+++ b/kura-examples/bundles/gpio/org.eclipse.kura.example.gpio/src/main/java/org/eclipse/kura/example/gpio/GpioComponentOCD.java
@@ -20,75 +20,71 @@ import org.osgi.service.metatype.annotations.Option;
 
 @SuppressWarnings("checkstyle:MethodName")
 @ObjectClassDefinition( //
-        id = "org.eclipse.kura.example.gpio.GpioComponent", //
-        name = "GPIO Configuration", //
-        description = "Example of a GPIO Configuring Application." //
+                id = "org.eclipse.kura.example.gpio.GpioComponent", //
+                name = "GPIO Configuration", //
+                description = "Example of a GPIO Configuring Application." //
 
 )
 @ComponentPropertyType
 public @interface GpioComponentOCD {
 
-    @AttributeDefinition(name = "Gpio Service Pid", //
-            description = "The Kura GPIO service to be used to interact with gpios.", //
-            required = true //
-    // <Icon resource="http://s3.amazonaws.com/kura-resources/application/icon/applications-other.png" size="32"/>
-    )
-    String gpio_service_pid() default "org.eclipse.kura.gpio.GPIOService";
+        @AttributeDefinition(name = "Gpio Service Pid", //
+                        description = "The Kura GPIO service to be used to interact with gpios.", //
+                        required = true //
+        )
+        String gpio_service_pid() default "org.eclipse.kura.gpio.GPIOService";
 
-    @AttributeDefinition(name = "Gpio Input Read Mode", //
-            description = "Specifies how input pin value is obtained. If set to PIN_STATUS_LISTENER, the pin value will be printed on the log on change, if set to POLLING, the pin value will be readed and printed on the log periodically.", //
-            required = true, //
-            options = { //
-                    @Option(label = "PIN_STATUS_LISTENER", value = "PIN_STATUS_LISTENER"), //
-                    @Option(label = "POLLING", value = "POLLING") //
-            })
-    String gpio_input_read_mode() default "PIN_STATUS_LISTENER";
+        @AttributeDefinition(name = "Gpio Input Read Mode", //
+                        description = "Specifies how input pin value is obtained. If set to PIN_STATUS_LISTENER, the pin value will be printed on the log on change, if set to POLLING, the pin value will be readed and printed on the log periodically.", //
+                        required = true, //
+                        options = { //
+                                        @Option(label = "PIN_STATUS_LISTENER", value = "PIN_STATUS_LISTENER"), //
+                                        @Option(label = "POLLING", value = "POLLING") //
+                        })
+        String gpio_input_read_mode() default "PIN_STATUS_LISTENER";
 
-    @AttributeDefinition(name = "Gpio Pins", //
-            description = "List of GPIO pins expressed as pin number (i.e. 1022), pin name (i.e. DOUT1, DIN1, ...) or gpiochip, line (i.e. 0,24).", //
-            required = false, //
-            cardinality = 5 //
-    )
-    String[] gpio_pins() default {};
+        @AttributeDefinition(name = "Gpio Pins", //
+                        description = "List of GPIO pins expressed as pin number (i.e. 1022), pin name (i.e. DOUT1, DIN1, ...) or controller:line (i.e. 0:24).", //
+                        required = false, //
+                        cardinality = 5 //
+        )
+        String[] gpio_pins() default {};
 
-    @AttributeDefinition(name = "Gpio Directions", //
-            description = "Pin directions", //
-            required = false, //
-            cardinality = 5, //
-            options = { //
-                    @Option(label = "Only input", value = "0"), //
-                    @Option(label = "Only output", value = "1"), //
-                    @Option(label = "Both, init input", value = "2"), //
-                    @Option(label = "Both, init output", value = "3") //
-            })
-    int[] gpio_directions() default { 3, 3, 3, 3, 3 };
+        @AttributeDefinition(name = "Gpio Directions", //
+                        description = "Pin directions", //
+                        required = false, //
+                        cardinality = 5, //
+                        options = { //
+                                        @Option(label = "Only input", value = "0"), //
+                                        @Option(label = "Only output", value = "1"), //
+                                        @Option(label = "Both, init input", value = "2"), //
+                                        @Option(label = "Both, init output", value = "3") //
+                        })
+        int[] gpio_directions() default { 3, 3, 3, 3, 3 };
 
-    @AttributeDefinition(name = "Gpio Modes", //
-            description = "Pin working mode", //
-            required = false, //
-            cardinality = 5, //
-            options = { //
-                    @Option(label = "Default", value = "-1"), //
-                    @Option(label = "Input with Pull Down", value = "2"), //
-                    @Option(label = "Input with Pull Up", value = "1"), //
-                    @Option(label = "Open Drain Output", value = "8"), //
-                    @Option(label = "Push-Pull Output", value = "4") //
-            })
-    int[] gpio_modes() default { -1, -1, -1, -1, -1 };
+        @AttributeDefinition(name = "Gpio Modes", //
+                        description = "Pin working mode", //
+                        required = false, //
+                        cardinality = 5, //
+                        options = { //
+                                        @Option(label = "Default", value = "-1"), //
+                                        @Option(label = "Input with Pull Down", value = "2"), //
+                                        @Option(label = "Input with Pull Up", value = "1"), //
+                                        @Option(label = "Open Drain Output", value = "8"), //
+                                        @Option(label = "Push-Pull Output", value = "4") //
+                        })
+        int[] gpio_modes() default { -1, -1, -1, -1, -1 };
 
-    @AttributeDefinition(name = "Gpio Triggers", //
-            description = "Input triggering mode", //
-            required = false, //
-            cardinality = 5, //
-            options = { //
-                    @Option(label = "Default", value = "-1"), //
-                    @Option(label = "No trigger", value = "0"), //
-                    @Option(label = "Rising edge", value = "2"), //
-                    @Option(label = "Both edges", value = "3"), //
-                    @Option(label = "Falling edge", value = "1") //
-            // <Option label="High level" value="4"/>
-            // <Option label="Low level" value="5"/>
-            // <Option label="Both levels" value="6"/>
-            })
-    int[] gpio_triggers() default { -1, -1, -1, -1, -1 };
+        @AttributeDefinition(name = "Gpio Triggers", //
+                        description = "Input triggering mode", //
+                        required = false, //
+                        cardinality = 5, //
+                        options = { //
+                                        @Option(label = "Default", value = "-1"), //
+                                        @Option(label = "No trigger", value = "0"), //
+                                        @Option(label = "Rising edge", value = "2"), //
+                                        @Option(label = "Both edges", value = "3"), //
+                                        @Option(label = "Falling edge", value = "1") //
+                        })
+        int[] gpio_triggers() default { -1, -1, -1, -1, -1 };
 }

--- a/kura-examples/bundles/gpio/org.eclipse.kura.example.gpio/src/main/java/org/eclipse/kura/example/gpio/GpioComponentOCD.java
+++ b/kura-examples/bundles/gpio/org.eclipse.kura.example.gpio/src/main/java/org/eclipse/kura/example/gpio/GpioComponentOCD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Eurotech and/or its affiliates and others
+ * Copyright (c) 2025, 2026 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura-examples/bundles/pom.xml
+++ b/kura-examples/bundles/pom.xml
@@ -364,7 +364,8 @@
         <module>modbus</module>
         <module>publishers</module>
         <module>security</module>
-        <module>sensehat</module>
+        <!-- Disable sensehat module for now -->
+        <!--<module>sensehat</module>-->
         <module>wire-components</module>
     </modules>
 </project>

--- a/kura-examples/kura-examples-bom/pom.xml
+++ b/kura-examples/kura-examples-bom/pom.xml
@@ -81,11 +81,11 @@
                 <artifactId>org.eclipse.kura.example.container.signature.validation</artifactId>
                 <version>${kura.examples.version}</version>
             </dependency>
-            <dependency>
+            <!--<dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.driver.sensehat</artifactId>
                 <version>${kura.examples.version}</version>
-            </dependency>
+            </dependency>-->
             <dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.example.eddystone.advertiser</artifactId>
@@ -163,7 +163,7 @@
             </dependency>
 
             <!-- Raspberry Pi SenseHat bundles -->
-            <dependency>
+            <!--<dependency>
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.raspberrypi.sensehat</artifactId>
                 <version>${kura.examples.version}</version>
@@ -172,7 +172,7 @@
                 <groupId>org.eclipse.kura</groupId>
                 <artifactId>org.eclipse.kura.raspberrypi.sensehat.example</artifactId>
                 <version>${kura.examples.version}</version>
-            </dependency>
+            </dependency>-->
 
             <!-- Wire development component -->
             <dependency>
@@ -215,10 +215,10 @@
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.container.signature.validation</artifactId>
         </dependency>
-        <dependency>
+        <!--<dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.driver.sensehat</artifactId>
-        </dependency>
+        </dependency>-->
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.example.eddystone.advertiser</artifactId>
@@ -281,14 +281,14 @@
         </dependency>
 
         <!-- Raspberry Pi SenseHat bundles -->
-        <dependency>
+        <!--<dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.raspberrypi.sensehat</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kura</groupId>
             <artifactId>org.eclipse.kura.raspberrypi.sensehat.example</artifactId>
-        </dependency>
+        </dependency>-->
 
         <!-- Wire development component -->
         <dependency>


### PR DESCRIPTION
This pull request updates the GPIO example bundle to improve GPIO pin selection flexibility and compatibility with newer Kura GPIO APIs. The main changes include expanding the supported formats for specifying GPIO pins, updating the code to use richer pin descriptions, and increasing the required version of the GPIO API.

**GPIO Pin Selection Enhancements:**

* Updated the `GpioComponentOCD.java` configuration to allow specifying GPIO pins by number, name, or as a composite string in the format `name:controller:line` (e.g., `"GPIO1:0:24"`), with support for wildcards and omitted fields for broader selection.
* Refactored the `GpioComponent.java` logic to support the new pin specification format, including parsing the resource string, handling wildcards, and acquiring multiple pins when appropriate.
* Updated logging and pin acquisition to use the new `KuraGPIODescription` API, providing more detailed information about available GPIOs.

**API and Version Updates:**

* Increased the required version of the `org.eclipse.kura.gpio` package to `[1.2,2.0)` in the bundle manifest, ensuring compatibility with the new API features.
* Updated copyright years in source files to 2026. [[1]](diffhunk://#diff-30be679a820aa90cef8c4bc2316089bc36c7db9e94544538ccce8f8aced9a6c0L2-R2) [[2]](diffhunk://#diff-b62519f089fabd7fe598bd68ba9bd817044d8e7a87e982d51835a24c304c0d8cL2-R2)

**Minor and Formatting Changes:**

* Cleaned up and clarified comments and formatting in the affected files. [[1]](diffhunk://#diff-30be679a820aa90cef8c4bc2316089bc36c7db9e94544538ccce8f8aced9a6c0L65-R70) [[2]](diffhunk://#diff-b62519f089fabd7fe598bd68ba9bd817044d8e7a87e982d51835a24c304c0d8cL34) [[3]](diffhunk://#diff-b62519f089fabd7fe598bd68ba9bd817044d8e7a87e982d51835a24c304c0d8cL89-L91)
* Fixed a comment typo and closed an XML comment in the target definition file.