### PR TITLE
build: updated deployment system with new shared library plugin pipeline

### DIFF
--- a/.jenkins/ci.groovy
+++ b/.jenkins/ci.groovy
@@ -1,4 +1,4 @@
-@Library('add-ons-shared-libs@develop') _
+@Library('add-ons-shared-libs@plugin/apps') _
 
 node {
     continuousIntegrationPipeline(

--- a/kura-addon-prototypes/tests/pom.xml
+++ b/kura-addon-prototypes/tests/pom.xml
@@ -166,8 +166,6 @@
                         <argLine>
                             ${tycho.testArgLine}
                             -Dosgi.console=5002
-                            -Declipse.security=osgi
-                            -Dorg.osgi.framework.security=osgi
                             -Dosgi.signedcontent.support=all
                             -XX:HeapDumpPath=/dev/null
                             -Dorg.eclipse.kura.mode=emulator

--- a/kura-apps-distrib/kura-addon-prototypes/pom.xml
+++ b/kura-apps-distrib/kura-addon-prototypes/pom.xml
@@ -60,29 +60,11 @@
 
     <properties>
 
-        <!--
-            With n being the start level, config.ini will be populated depending on which plugins directory the
-        bundle is put:
-            n => bundle.name:@n;
-            ns => bundle.name:@n:start;
-        -->
-        <addon.installation.dir>/opt/eclipse/kura/plugins/6s</addon.installation.dir>
-
         <!-- name of the JAR produced in bundles/target -->
         <jar.name>kura-addon-prototypes.bundle-1.0.0-SNAPSHOT.jar</jar.name>
 
-        <!--
-            Available DEB architectures:
-            all, amd64, arm64
-        -->
-        <deb.architecture>all</deb.architecture>
-
         <!-- final name of the generated debian package -->
         <package.name>kura-addon-prototypes</package.name>
-
-        <!-- properties used for artifact upload on artifactory repository -->
-        <kura.repo.distribution>kura-6</kura.repo.distribution>
-        <kura.repo.module>base</kura.repo.module>
 
         <!-- edit following fields and file deb/control/control -->
         <summary>Eclipse Kura Addon Prototypes</summary>

--- a/kura-apps-distrib/kura-examples/ble/pom.xml
+++ b/kura-apps-distrib/kura-examples/ble/pom.xml
@@ -72,12 +72,8 @@
     </build>
 
     <properties>
-        <addon.installation.dir>/opt/eclipse/kura/plugins/6s</addon.installation.dir>
         <jar.name>kura-ble-examples.bundle--${project.version}.jar</jar.name>
-        <deb.architecture>all</deb.architecture>
         <package.name>kura-ble-examples</package.name>
-        <kura.repo.distribution>kura-6</kura.repo.distribution>
-        <kura.repo.module>base</kura.repo.module>
         <summary>Eclipse Kura Addon Examples for BLE</summary>
         <long.description>Examples of BLE addons for the Eclipse Kura Framework.</long.description>
     </properties>

--- a/kura-apps-distrib/kura-examples/camel/pom.xml
+++ b/kura-apps-distrib/kura-examples/camel/pom.xml
@@ -44,12 +44,8 @@
     </dependencies>
 
     <properties>
-        <addon.installation.dir>/opt/eclipse/kura/plugins/6s</addon.installation.dir>
         <jar.name>kura-camel-example.bundle-${project.version}.jar</jar.name>
-        <deb.architecture>all</deb.architecture>
         <package.name>kura-camel-example</package.name>
-        <kura.repo.distribution>kura-6</kura.repo.distribution>
-        <kura.repo.module>base</kura.repo.module>
         <summary>Eclipse Kura Addon for Camel</summary>
         <long.description>Examples of Camel addons for the Eclipse Kura Framework.</long.description>
     </properties>

--- a/kura-apps-distrib/kura-examples/can/pom.xml
+++ b/kura-apps-distrib/kura-examples/can/pom.xml
@@ -37,12 +37,8 @@
     </dependencies>
 
     <properties>
-        <addon.installation.dir>/opt/eclipse/kura/plugins/6s</addon.installation.dir>
         <jar.name>kura-can-example.bundle-${project.version}.jar</jar.name>
-        <deb.architecture>all</deb.architecture>
         <package.name>kura-can-example</package.name>
-        <kura.repo.distribution>kura-6</kura.repo.distribution>
-        <kura.repo.module>base</kura.repo.module>
         <summary>Eclipse Kura Addon for CAN</summary>
         <long.description>Examples of CAN addons for the Eclipse Kura Framework.</long.description>
     </properties>

--- a/kura-apps-distrib/kura-examples/container-validation/pom.xml
+++ b/kura-apps-distrib/kura-examples/container-validation/pom.xml
@@ -36,12 +36,8 @@
     </dependencies>
 
     <properties>
-        <addon.installation.dir>/opt/eclipse/kura/plugins/6s</addon.installation.dir>
         <jar.name>kura-container-validation-example.bundle-${project.version}.jar</jar.name>
-        <deb.architecture>all</deb.architecture>
         <package.name>kura-container-validation-example</package.name>
-        <kura.repo.distribution>kura-6</kura.repo.distribution>
-        <kura.repo.module>base</kura.repo.module>
         <summary>Eclipse Kura Addon for Container Validation</summary>
         <long.description>Examples of Container Validation addons for the Eclipse Kura Framework.</long.description>
     </properties>

--- a/kura-apps-distrib/kura-examples/gpio/pom.xml
+++ b/kura-apps-distrib/kura-examples/gpio/pom.xml
@@ -40,12 +40,8 @@
     </dependencies>
 
     <properties>
-        <addon.installation.dir>/opt/eclipse/kura/plugins/6s</addon.installation.dir>
         <jar.name>kura-gpio-example.bundle-${project.version}.jar</jar.name>
-        <deb.architecture>all</deb.architecture>
         <package.name>kura-gpio-example</package.name>
-        <kura.repo.distribution>kura-6</kura.repo.distribution>
-        <kura.repo.module>base</kura.repo.module>
         <summary>Eclipse Kura Addon for GPIO</summary>
         <long.description>Examples of GPIO addons for the Eclipse Kura Framework.</long.description>
     </properties>

--- a/kura-apps-distrib/kura-examples/heater/pom.xml
+++ b/kura-apps-distrib/kura-examples/heater/pom.xml
@@ -36,12 +36,8 @@
     </dependencies>
 
     <properties>
-        <addon.installation.dir>/opt/eclipse/kura/plugins/6s</addon.installation.dir>
         <jar.name>kura-heater-example.bundle-${project.version}.jar</jar.name>
-        <deb.architecture>all</deb.architecture>
         <package.name>kura-heater-example</package.name>
-        <kura.repo.distribution>kura-6</kura.repo.distribution>
-        <kura.repo.module>base</kura.repo.module>
         <summary>Eclipse Kura Addon for Heater</summary>
         <long.description>Examples of Heater addons for the Eclipse Kura Framework.</long.description>
     </properties>

--- a/kura-apps-distrib/kura-examples/identity/pom.xml
+++ b/kura-apps-distrib/kura-examples/identity/pom.xml
@@ -36,12 +36,8 @@
     </dependencies>
 
     <properties>
-        <addon.installation.dir>/opt/eclipse/kura/plugins/6s</addon.installation.dir>
         <jar.name>kura-identity-example.bundle-${project.version}.jar</jar.name>
-        <deb.architecture>all</deb.architecture>
         <package.name>kura-identity-example</package.name>
-        <kura.repo.distribution>kura-6</kura.repo.distribution>
-        <kura.repo.module>base</kura.repo.module>
         <summary>Eclipse Kura Addon for Identity</summary>
         <long.description>Examples of Identity addons for the Eclipse Kura Framework.</long.description>
     </properties>

--- a/kura-apps-distrib/kura-examples/modbus/pom.xml
+++ b/kura-apps-distrib/kura-examples/modbus/pom.xml
@@ -36,12 +36,8 @@
     </dependencies>
 
     <properties>
-        <addon.installation.dir>/opt/eclipse/kura/plugins/6s</addon.installation.dir>
         <jar.name>kura-modbus-example.bundle-${project.version}.jar</jar.name>
-        <deb.architecture>all</deb.architecture>
         <package.name>kura-modbus-example</package.name>
-        <kura.repo.distribution>kura-6</kura.repo.distribution>
-        <kura.repo.module>base</kura.repo.module>
         <summary>Eclipse Kura Addon for Modbus</summary>
         <long.description>Examples of Modbus addons for the Eclipse Kura Framework.</long.description>
     </properties>

--- a/kura-apps-distrib/kura-examples/publishers/pom.xml
+++ b/kura-apps-distrib/kura-examples/publishers/pom.xml
@@ -40,12 +40,8 @@
     </dependencies>
 
     <properties>
-        <addon.installation.dir>/opt/eclipse/kura/plugins/6s</addon.installation.dir>
         <jar.name>kura-publishers-example.bundle-${project.version}.jar</jar.name>
-        <deb.architecture>all</deb.architecture>
         <package.name>kura-publishers-example</package.name>
-        <kura.repo.distribution>kura-6</kura.repo.distribution>
-        <kura.repo.module>base</kura.repo.module>
         <summary>Eclipse Kura Addon for Publishers</summary>
         <long.description>Examples of Publishers addons for the Eclipse Kura Framework.</long.description>
     </properties>

--- a/kura-apps-distrib/kura-examples/security/pom.xml
+++ b/kura-apps-distrib/kura-examples/security/pom.xml
@@ -40,12 +40,8 @@
     </dependencies>
 
     <properties>
-        <addon.installation.dir>/opt/eclipse/kura/plugins/6s</addon.installation.dir>
         <jar.name>kura-security-example.bundle-${project.version}.jar</jar.name>
-        <deb.architecture>all</deb.architecture>
         <package.name>kura-security-example</package.name>
-        <kura.repo.distribution>kura-6</kura.repo.distribution>
-        <kura.repo.module>base</kura.repo.module>
         <summary>Eclipse Kura Addon for Security</summary>
         <long.description>Examples of Security addons for the Eclipse Kura Framework.</long.description>
     </properties>

--- a/kura-apps-distrib/kura-examples/sensehat/pom.xml
+++ b/kura-apps-distrib/kura-examples/sensehat/pom.xml
@@ -44,12 +44,8 @@
     </dependencies>
 
     <properties>
-        <addon.installation.dir>/opt/eclipse/kura/plugins/6s</addon.installation.dir>
         <jar.name>kura-sensehat-example.bundle-${project.version}.jar</jar.name>
-        <deb.architecture>all</deb.architecture>
         <package.name>kura-sensehat-example</package.name>
-        <kura.repo.distribution>kura-6</kura.repo.distribution>
-        <kura.repo.module>base</kura.repo.module>
         <summary>Eclipse Kura Addon for SenseHat</summary>
         <long.description>Examples of SenseHat addons for the Eclipse Kura Framework.</long.description>
     </properties>

--- a/kura-apps-distrib/kura-examples/wire-components/pom.xml
+++ b/kura-apps-distrib/kura-examples/wire-components/pom.xml
@@ -52,12 +52,8 @@
     </dependencies>
 
     <properties>
-        <addon.installation.dir>/opt/eclipse/kura/plugins/6s</addon.installation.dir>
         <jar.name>kura-wire-components-example.bundle-${project.version}.jar</jar.name>
-        <deb.architecture>all</deb.architecture>
         <package.name>kura-wire-components-example</package.name>
-        <kura.repo.distribution>kura-6</kura.repo.distribution>
-        <kura.repo.module>base</kura.repo.module>
         <summary>Eclipse Kura Addon for Wire Components</summary>
         <long.description>Examples of Wire Components addons for the Eclipse Kura Framework.</long.description>
     </properties>

--- a/kura-apps-distrib/pom.xml
+++ b/kura-apps-distrib/pom.xml
@@ -40,6 +40,17 @@
         </snapshotRepository>
     </distributionManagement>
 
+    <!-- Properties shared between all distrib poms in submodules -->
+    <properties>
+        <!-- properties used for artifact upload on artifactory repository -->
+        <kura.repo.distribution>kura-6</kura.repo.distribution>
+        <kura.repo.module>base</kura.repo.module>
+
+        <deb.architecture>all</deb.architecture>
+
+        <addon.installation.dir>/opt/eclipse/kura/plugins/6s</addon.installation.dir>
+    </properties>
+
     <modules>
         <module>kura-examples</module>
         <module>kura-addon-prototypes</module>

--- a/kura-examples/tests/pom.xml
+++ b/kura-examples/tests/pom.xml
@@ -172,8 +172,6 @@
                         <argLine>
                             ${tycho.testArgLine}
                             -Dosgi.console=5002
-                            -Declipse.security=osgi
-                            -Dorg.osgi.framework.security=osgi
                             -Dosgi.signedcontent.support=all
                             -XX:HeapDumpPath=/dev/null
                             -Dorg.eclipse.kura.mode=emulator


### PR DESCRIPTION
The kura-apps repo differs from the classic structures of the addons, since the distrib folder is called kura-apps-distrib, due to the separation between kura-examples and kura-addon-prototypes. Moreover, the kura-examples folder contains all the examples grouped by type (ble, security and so on).

For this reason, we created a custom pipeline in the [add-on-shared repo](https://github.com/eclipse-kura/add-ons-shared-libraries) under branch `plugin/apps` and this PR makes the necessary changes to adapt on the new pipeline.

- The properties shared among all the distrib poms are now declared once under the kura-apps-distrib/pom.xml
- Removed the same properties duplicated in all other poms
- updated the ci.groovy to point to new branch on add-on-shared