### PR TITLE
build: removing sonar checks

### DIFF
--- a/.jenkins/ci.groovy
+++ b/.jenkins/ci.groovy
@@ -7,7 +7,7 @@ node {
             enable: true,
             projectKey: "eclipse-kura_kura-apps",
             tokenId: "sonarcloud-token-kura-apps",
-            exclusions: "kura-examples/tests/**/*,kura-addon-prototypes/tests/**/***/*.xml,**/*.yml",
+            exclusions: "**/*",
             testExclusions: "**/*"
         ],
     )


### PR DESCRIPTION
The kura-apps repo aim is to show users examples and prototypes to be used in the framework or taken as hints for development. Due to its nature, the repo is full of duplications, old code and stuff like this, so sonar complains a lot and the CI doesn't pass.
We think that it useless to have a sonar cloud scan on this repo, since it's not code that will be deployed somewhere. This PR tries to suppress the sonar scan.